### PR TITLE
Typed arrays

### DIFF
--- a/lib/convnet.js
+++ b/lib/convnet.js
@@ -948,9 +948,13 @@ var convnetjs = (function(exports){
   // array stuff
   function zeros(n) {
     if(typeof(n)==='undefined' || isNaN(n)) { return []; }
-    return floatArray(n);
-    //for(var i=0;i<n;i++) { arr[i]= 0; }
-    //return arr;
+    if(typeof ArrayBuffer !== 'undefined'){
+        return floatArray(n);
+    }else{
+        var arr = [];
+        for(var i=0;i<n;i++) { arr[i]= 0; }
+        return arr;
+    }
   }
 
   function floatArray(n){


### PR DESCRIPTION
I had a go at using typed arrays (where available) for w & dw in Vol (and return value of zeros function). Running in Chrome Canary, there seems to be a bit of a performance increase - the first 1000 examples in the MNIST demo went from taking ~16s to ~12s on my machine (Chrome 34.0.1769.2, Windows 8.0).
