### PR TITLE
Trigger a warning when regression trainer is not given an array 

### DIFF
--- a/src/convnet_trainers.js
+++ b/src/convnet_trainers.js
@@ -24,7 +24,7 @@
     this.xsum = []; // used in adam or adadelta
 
     // check if regression is expected 
-    if(this.net.layers[this.net.layers.length].layer_type === "regression")
+    if(this.net.layers[this.net.layers.length - 1].layer_type === "regression")
       this.regression = true;
     else
       this.regression = false;

--- a/src/convnet_trainers.js
+++ b/src/convnet_trainers.js
@@ -22,6 +22,12 @@
     this.k = 0; // iteration counter
     this.gsum = []; // last iteration gradients (used for momentum calculations)
     this.xsum = []; // used in adam or adadelta
+
+    // check if regression is expected 
+    if(this.net.layers[this.net.layers.length].layer_type === "regression")
+      this.regression = true;
+    else
+      this.regression = false;
   }
 
   Trainer.prototype = {
@@ -38,6 +44,9 @@
       var l1_decay_loss = 0.0;
       var end = new Date().getTime();
       var bwd_time = end - start;
+
+      if(this.regression && y.constructor !== Array)
+        console.log("Warning: a regression net requires an array as training output vector.");
       
       this.k++;
       if(this.k % this.batch_size === 0) {


### PR DESCRIPTION
When you train a network for regression and that you want to predict only one value it is very tricky that the trainer should take **an array of one value**:

```
var stats = trainer.train(line.x, [line.y]);
```

i just added a console log so that beginners users realise this quickly (i've seen two people fall in this trap in a short interval).