### PR TITLE
fix deepqlearn nodejs dep; precompiled

### DIFF
--- a/build/deepqlearn.js
+++ b/build/deepqlearn.js
@@ -1,4 +1,7 @@
 var deepqlearn = deepqlearn || { REVISION: 'ALPHA' };
+// dependencies linked for nodejs
+var convnetjs = require(__dirname+'/convnet.js');
+var cnnutil = require(__dirname+'/util.js');
 
 (function(global) {
   "use strict";

--- a/src/convnet_export.js
+++ b/src/convnet_export.js
@@ -3,6 +3,10 @@
   if (typeof module === "undefined" || typeof module.exports === "undefined") {
     window.convnetjs = lib; // in ordinary browser attach library to window
   } else {
+  	// for nodejs, call by var deepqlearn = convnetjs.deepqlearn()
+  	lib.deepqlearn = function() {
+      return require(__dirname+'/deepqlearn.js');
+    };
     module.exports = lib; // in nodejs
   }
 })(convnetjs);


### PR DESCRIPTION
Hi dude,
This is a long-due fix for using `deepqlearn` in `nodejs`, as I mentioned in issue #48 
I noticed `convnet.js` is compiled from multiple sources, so I added the needed code too.
Tested in `nodejs`; you may wish to test in browser first before merging.
