### PR TITLE
fix dropout prob

### DIFF
--- a/src/convnet_layers_dropout.js
+++ b/src/convnet_layers_dropout.js
@@ -33,7 +33,7 @@
         }
       } else {
         // scale the activations during prediction
-        for(var i=0;i<N;i++) { V2.w[i]*=this.drop_prob; }
+        for(var i=0;i<N;i++) { V2.w[i]*=(1-this.drop_prob); }
       }
       this.out_act = V2;
       return this.out_act; // dummy identity function for now


### PR DESCRIPTION
Hello, Andrej @karpathy 

I think here should be (1-this.drop_prob). Let's consider probability = 0.1 - we should drop 10% and after that scale weights only slightly onto 0.9.

WBR,
Dmitriy
