### PR TITLE
Fix adam optimizer

### DIFF
--- a/src/convnet_trainers.js
+++ b/src/convnet_trainers.js
@@ -96,8 +96,8 @@
               // adam update
               gsumi[j] = gsumi[j] * this.beta1 + (1- this.beta1) * gij; // update biased first moment estimate
               xsumi[j] = xsumi[j] * this.beta2 + (1-this.beta2) * gij * gij; // update biased second moment estimate
-              var biasCorr1 = gsumi[j] * (1 - Math.pow(this.beta1, this.k)); // correct bias first moment estimate
-              var biasCorr2 = xsumi[j] * (1 - Math.pow(this.beta2, this.k)); // correct bias second moment estimate
+              var biasCorr1 = gsumi[j] / (1 - Math.pow(this.beta1, this.k)); // correct bias first moment estimate
+              var biasCorr2 = xsumi[j] / (1 - Math.pow(this.beta2, this.k)); // correct bias second moment estimate
               var dx =  - this.learning_rate * biasCorr1 / (Math.sqrt(biasCorr2) + this.eps);
               p[j] += dx;
             } else if(this.method === 'adagrad') {


### PR DESCRIPTION
Hi Andrej,

I recently ran the trainer demo on MNIST and wondered why the Adam optimizer performs so much more worse than Adadelta.

I think I found a little bug in the Adam implementation.

According to the Adam Paper-v8 https://arxiv.org/pdf/1412.6980v8.pdf **Algorithm 1** (p. 2) the bias estimates use division instead of multiplication. The fixed version behaves significantly better when running the trainer demo on MNIST. To get the results as below I also changed the learning rate to 0.001 and the beta2 parameter to 0.999 (from 0.01 and 0.99 respectively) as recommended in the paper.

Before:
<img width="814" alt="screen shot 2016-08-04 at 21 14 48" src="https://cloud.githubusercontent.com/assets/10101036/17415472/49d8aa98-5a8a-11e6-8961-8b1e68599f55.png">

After:
<img width="802" alt="screen shot 2016-08-04 at 21 21 27" src="https://cloud.githubusercontent.com/assets/10101036/17415430/214938a4-5a8a-11e6-9f3d-c29ec7cecd79.png">
