### PR TITLE
Allow to work in non-browser env

### DIFF
--- a/src/convnet_export.js
+++ b/src/convnet_export.js
@@ -1,7 +1,8 @@
 (function(lib) {
   "use strict";
   if (typeof module === "undefined" || typeof module.exports === "undefined") {
-    window.convnetjs = lib; // in ordinary browser attach library to window
+    // By declaring convnetjs globally, we have already made it available.
+    // Nothing to do here.
   } else {
     module.exports = lib; // in nodejs
   }


### PR DESCRIPTION
‘window’ is specific to browser environments. ‘this’ (the global object is the default ‘this’ value) allows it to work in non-browser environments other than node.