### PR TITLE
Prevent Regression Layer from being NaN

### DIFF
--- a/src/convnet_layers_loss.js
+++ b/src/convnet_layers_loss.js
@@ -137,6 +137,9 @@
         var i = y.dim;
         var yi = y.val;
         var dy = x.w[i] - yi;
+        if (isNaN(dy)) {
+          dy = 0;
+        }
         x.dw[i] = dy;
         loss += 0.5*dy*dy;
       }


### PR DESCRIPTION
Since x.w[i] or yi can yet be defined, if it is invalid math, we should set the change in y to 0.

This caused a lot of NaN's in brain otherwise.