### PR TITLE
Scaling dropout layer by keep probability during test time

### DIFF
--- a/src/convnet_layers_dropout.js
+++ b/src/convnet_layers_dropout.js
@@ -33,7 +33,8 @@
         }
       } else {
         // scale the activations during prediction
-        for(var i=0;i<N;i++) { V2.w[i]*=this.drop_prob; }
+        var keep_prob = 1 - this.drop_prob;
+        for(var i=0;i<N;i++) { V2.w[i]*=keep_prob; }
       }
       this.out_act = V2;
       return this.out_act; // dummy identity function for now


### PR DESCRIPTION
From the dropout paper http://www.cs.toronto.edu/~rsalakhu/papers/srivastava14a.pdf : 

>   If a unit is *retained* with probability p during training, the outgoing weights of that unit are multiplied by p at test time

The test activations should be scaled by `(1-drop_prob)`, not `drop_prob`. 
For example, if drop prob is 0, this layer should have no effect and we should scale activations by 1. 