### PR TITLE
Fixed bias correction error in adam optimizer

### DIFF
--- a/src/convnet_trainers.js
+++ b/src/convnet_trainers.js
@@ -96,8 +96,8 @@
               // adam update
               gsumi[j] = gsumi[j] * this.beta1 + (1- this.beta1) * gij; // update biased first moment estimate
               xsumi[j] = xsumi[j] * this.beta2 + (1-this.beta2) * gij * gij; // update biased second moment estimate
-              var biasCorr1 = gsumi[j] * (1 - Math.pow(this.beta1, this.k)); // correct bias first moment estimate
-              var biasCorr2 = xsumi[j] * (1 - Math.pow(this.beta2, this.k)); // correct bias second moment estimate
+              var biasCorr1 = gsumi[j] / (1 - Math.pow(this.beta1, this.k)); // correct bias first moment estimate
+              var biasCorr2 = xsumi[j] / (1 - Math.pow(this.beta2, this.k)); // correct bias second moment estimate
               var dx =  - this.learning_rate * biasCorr1 / (Math.sqrt(biasCorr2) + this.eps);
               p[j] += dx;
             } else if(this.method === 'adagrad') {


### PR DESCRIPTION
The algorithm described in section 2 of the Adam paper (https://arxiv.org/pdf/1412.6980.pdf) differs slightly from the current implementation. 

![image](https://user-images.githubusercontent.com/2518580/51793656-a3aaee00-21bb-11e9-8b92-9106a77e1b1f.png)

The lines for m-hat and v-hat correspond to the lines in this pull request for biasCorr1 and biasCorr2. 